### PR TITLE
Add few more options to template and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ helm install my-release .
 
 ## Configuration
 
-The following table lists the configurable parameters of the Statusbay chart.      
+The following table lists the configurable parameters of the Statusbay chart.
 
 Parameter | Description | Default
 --------- | ----------- | -------
@@ -35,6 +35,8 @@ Parameter | Description | Default
 `database.username` | The username of database | `statusbay`
 `database.password` | The password of database | `changeme`
 `database.schema` | The schema name of database | `statusbay`
+`database.internal.sercice.type` | The service type to be used | `ClusterIP`
+`database.internal.sercice.annotations` | The annotations used in the service | `{}`
 `database.internal.image.repository` | container image repository | `mysql`
 `database.internal.image.tag` | container image tag | `5.7`
 `database.internal.image.pullPolicy` | container image pull policy | `IfNotPresent`
@@ -48,6 +50,8 @@ Parameter | Description | Default
 `redis.port` | The port of redis, redundant if you're using internal redis | `6379`
 `redis.password` | The password of Redis | ``
 `redis.db` | The DB of Redis | `0`
+`redis.internal.sercice.type` | The service type to be used | `ClusterIP`
+`redis.internal.sercice.annotations` | The annotations used in the service | `{}`
 `redis.internal.image.repository` | container image repository | `redis`
 `redis.internal.image.tag` | container image tag | `5.0.7`
 `redis.internal.image.pullPolicy` | container image pull policy | `IfNotPresent`
@@ -58,8 +62,10 @@ Parameter | Description | Default
 | **Ingress** |
 `ingress.api.annotations` | The annotations used in ingress | `{}`
 `ingress.api.host` | The host of Statusbay ingress api | `api.statusbay.domain`
+`ingress.api.use_tls` | If Ingress should configure a TLS for this host | `false`
 `ingress.ui.annotations` | The annotations used in ingress for the UI | `{}`
 `ingress.ui.host` | The host of StatusBay ingress UI | `statusbay.domain`
+`ingress.ui.use_tls` | If Ingress should configure a TLS for this host | `false`
 | **Service** |
 `service.api.type` | The type of api service to create  | `ClusterIP`
 `service.api.annotations` | The annotations used in api service | `{}`
@@ -88,8 +94,8 @@ Parameter | Description | Default
 `api.annotations` | The annotations used in api deployment | `{}`
 `api.application.log.level` | The application log level | `info`
 `api.application.log.gelf_address` | The address for ship the log out for external system | undefined
-`api.application.metrics.datadog.api_key` | The datadog provider api key | 
-`api.application.metrics.datadog.app_key` | The datadog provider app key |  
+`api.application.metrics.datadog.api_key` | The datadog provider api key |
+`api.application.metrics.datadog.app_key` | The datadog provider app key |
 `api.application.metrics.datadog.cache_expiration` | The metric response cache expiration | undefined
 `api.application.metrics.prometheus.address` | The prometheus address | undefined
 `api.application.alerts.statuscake.endpoint` | The Statuscake endpoint | undefined

--- a/templates/database/service.yaml
+++ b/templates/database/service.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
 {{ include "statusbay.labels" . | indent 4 }}
   annotations:
-{{- if .Values.database.internal.annotations }}
-{{ toYaml .Values.database.internal.annotations | indent 4 }}
+{{- if .Values.database.internal.service.annotations }}
+{{ toYaml .Values.database.internal.service.annotations | indent 4 }}
 {{- end }}
 {{ include "statusbay.annotations" . | indent 4 }}
 spec:
-{{- if .Values.database.internal.type }}
-  type: {{ .Values.database.internal.type }}
+{{- if .Values.database.internal.service.type }}
+  type: {{ .Values.database.internal.service.type }}
 {{- end }}
   selector:
 {{ include "statusbay.matchLabels" . | indent 4 }}

--- a/templates/database/service.yaml
+++ b/templates/database/service.yaml
@@ -6,8 +6,14 @@ metadata:
   labels:
 {{ include "statusbay.labels" . | indent 4 }}
   annotations:
+{{- if .Values.database.internal.annotations }}
+{{ toYaml .Values.database.internal.annotations | indent 4 }}
+{{- end }}
 {{ include "statusbay.annotations" . | indent 4 }}
 spec:
+{{- if .Values.database.internal.type }}
+  type: {{ .Values.database.internal.type }}
+{{- end }}
   selector:
 {{ include "statusbay.matchLabels" . | indent 4 }}
     component: database

--- a/templates/ingress/api.yaml
+++ b/templates/ingress/api.yaml
@@ -19,4 +19,9 @@ spec:
             backend:
               serviceName: {{ include "statusbay.fullname" . }}-api
               servicePort: {{ .Values.service.api.externalPort }}
+{{- if .Values.ingress.api.use_tls }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.api.host }}
+{{- end }}
 {{- end -}}

--- a/templates/ingress/ui.yaml
+++ b/templates/ingress/ui.yaml
@@ -19,4 +19,9 @@ spec:
             backend:
               serviceName: {{ include "statusbay.fullname" . }}-ui
               servicePort: {{ .Values.service.ui.externalPort }}
+{{- if .Values.ingress.api.use_tls }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.api.host }}
+{{- end }}
 {{- end -}}

--- a/templates/redis/service.yaml
+++ b/templates/redis/service.yaml
@@ -6,8 +6,14 @@ metadata:
   labels:
 {{ include "statusbay.labels" . | indent 4 }}
   annotations:
+{{- if .Values.redis.internal.service.annotations }}
+{{ toYaml .Values.redis.internal.service.annotations | indent 4 }}
+{{- end }}
 {{ include "statusbay.annotations" . | indent 4 }}
 spec:
+{{- if .Values.redis.internal.service.type }}
+  type: {{ .Values.redis.internal.service.type }}
+{{- end }}
   selector:
 {{ include "statusbay.matchLabels" . | indent 4 }}
     component: redis

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,8 @@ database:
   schema: statusbay
 
   internal:
+    annotations: {}
+    # type: ClusterIP
     image:
       repository: mysql
       tag: 5.7
@@ -22,9 +24,9 @@ database:
        memory: 256Mi
        cpu: 100m
     persistence:
-      persistentVolumeClaim:      
+      persistentVolumeClaim:
         accessMode: ReadWriteOnce
-        storageClass: "-" 
+        storageClass: "-"
         size: 1Gi
 
 redis:
@@ -32,7 +34,7 @@ redis:
 
   host: 127.0.0.1 # Redundent if using internal
   port: 6379 # Redundent if using internal
-  password: 
+  password:
   db: 0
 
   internal:
@@ -45,18 +47,20 @@ redis:
        memory: 256Mi
        cpu: 100m
     persistence:
-      persistentVolumeClaim:      
+      persistentVolumeClaim:
         accessMode: ReadWriteOnce
-        storageClass: "-" 
+        storageClass: "-"
         size: 1Gi
 
 ingress:
   api:
     annotations: {}
     host: api.statusbay.domain
+    # use_tls: false
   ui:
     annotations: {}
     host: statusbay.domain
+    # use_tls: false
 
 service:
   api:
@@ -66,31 +70,31 @@ service:
   ui:
     type: ClusterIP
     annotations: {}
-    externalPort: 80    
+    externalPort: 80
 
 rbac:
   create: true
 
 serviceAccount:
   create: true
-  name: 
+  name:
 
 ui:
   create: true
   replicas: 3
   annotations: {}
-  
+
   image:
     repository: similarweb/statusbay-ui
     tag: 0.1.6
     pullPolicy: IfNotPresent
-  
+
   # environmentVars is a list of  enviroment variables to set with the UI deployment. These could be
   # used to set API_URL (using helm configured in helpers),GELF ADDRESS & LOG_LEVEL.
   environmentVars:
     GELF_ADDRESS: 127.0.0.1
     LOG_LEVEL: INFO
-  
+
   resources:
     requests:
       cpu: 100m
@@ -100,7 +104,7 @@ api:
   create: true
   replicas: 2
   annotations: {}
-  application:    
+  application:
     log:
       level: INFO
       # gelf_address: 127.0.0.1

--- a/values.yaml
+++ b/values.yaml
@@ -13,8 +13,9 @@ database:
   schema: statusbay
 
   internal:
-    annotations: {}
-    # type: ClusterIP
+    service:
+      annotations: {}
+      # type: ClusterIP
     image:
       repository: mysql
       tag: 5.7
@@ -38,6 +39,9 @@ redis:
   db: 0
 
   internal:
+    service:
+      annotations: {}
+      # type: ClusterIP
     image:
       repository: redis
       tag: 5.0.7

--- a/watcher.yaml.example
+++ b/watcher.yaml.example
@@ -1,7 +1,7 @@
 image:
   repository: similarweb/statusbay
-  tag: 1.5
-  pullPolicy: Always
+  tag: 0.1.6
+  pullPolicy: IfNotPresent
 
 database:
   # Make sure all your K8S clusters have access to the main Database.
@@ -18,9 +18,12 @@ rbac:
 
 serviceAccount:
   create: true
-  name: 
+  name:
 
 api:
+  create: false
+
+ui:
   create: false
 
 watcher:


### PR DESCRIPTION
Added the following options:

* database.internal.annotations: Allows to define annotations
for the service
* database.internal.type: Allows to define the Service type defaults
to ClusterIP
* ingress.*.use_tls: Sets the Ingress to use the tls field with the
hosts configured. TLS to be used it not implemented yet

Also fixed some values in the watcher-only template:

* Fixed version from 1.5 to 0.1.6 to match the values.yaml
* Added a ui.create: false to disable UI creation