### PR TITLE
Fix ui and api service annotations missing key

### DIFF
--- a/templates/api/service.yaml
+++ b/templates/api/service.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
 {{ include "statusbay.labels" . | indent 4 }}
   annotations:
-{{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- if .Values.service.api.annotations }}
+{{ toYaml .Values.service.api.annotations | indent 4 }}
 {{- end }}
 {{ include "statusbay.annotations" . | indent 4 }}
 spec:

--- a/templates/ui/service.yaml
+++ b/templates/ui/service.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
 {{ include "statusbay.labels" . | indent 4 }}
   annotations:
-{{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4}}
+{{- if .Values.service.ui.annotations }}
+{{ toYaml .Values.service.ui.annotations | indent 4}}
 {{- end }}
 {{ include "statusbay.annotations" . | indent 4 }}
 spec:


### PR DESCRIPTION
Services for both api and ui were missing their nested keys, thus, custom service annotations were not applied.