### PR TITLE
Fix multiple conditions in if statement

### DIFF
--- a/templates/watcher/serviceaccount.yaml
+++ b/templates/watcher/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.serviceAccount.create) (.Values.watcher.kubernetes.create) }}
+{{- if and .Values.serviceAccount.create .Values.watcher.kubernetes.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This change fixes this error:
```
$ helm install -f values.yaml statusbay .
Error: template: statusbay-helm/templates/watcher/serviceaccount.yaml:1:7: executing "statusbay-helm/templates/watcher/serviceaccount.yaml" at <(.Values.serviceAccount.create) (.Values.watcher.kubernetes.create)>: can't give argument to non-function .Values.serviceAccount.create
```

This is my Helm version:
```
$ helm version
version.BuildInfo{Version:"v3.2.0", GitCommit:"e11b7ce3b12db2941e90399e874513fbd24bcb71", GitTreeState:"clean", GoVersion:"go1.14.2"}
```