### PR TITLE
fix: ui ingress tls

### DIFF
--- a/templates/ingress/ui.yaml
+++ b/templates/ingress/ui.yaml
@@ -19,9 +19,9 @@ spec:
             backend:
               serviceName: {{ include "statusbay.fullname" . }}-ui
               servicePort: {{ .Values.service.ui.externalPort }}
-{{- if .Values.ingress.api.use_tls }}
+{{- if .Values.ingress.ui.use_tls }}
   tls:
     - hosts:
-      - {{ .Values.ingress.api.host }}
+      - {{ .Values.ingress.ui.host }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
The issue is that it reads the values of the API which is wrong as the host of the API is different than the host of the UI and the same thing applies to the `use_tls`